### PR TITLE
Sinon-Chai was not included in commandline (brunch test)

### DIFF
--- a/test/test-helpers.coffee
+++ b/test/test-helpers.coffee
@@ -1,4 +1,8 @@
 # This file will be automatically required when using `brunch test` command.
+chai = require("chai");
+sinonChai = require("sinon-chai");
+chai.use(sinonChai);
+
 module.exports =
-  expect: require('chai').expect
+  expect: chai.expect
   sinon: require 'sinon'


### PR DESCRIPTION
When running test both in browser (mocha browser runner) and with "brunch test",
I noticed a discrepancy.

The browser includes sinon-chai, but "brunch test" does not!

This includes sinon-chai and fixes the issue.
