### PR TITLE
fix header link to /test (make relative, not absolute)

### DIFF
--- a/app/models/header.coffee
+++ b/app/models/header.coffee
@@ -3,7 +3,7 @@ Model = require 'models/base/model'
 module.exports = class Header extends Model
   defaults:
     items: [
-      {href: '/test/', title: 'App Tests'},
+      {href: './test/', title: 'App Tests'},
       {href: 'http://brunch.readthedocs.org/', title: 'Docs'},
       {href: 'https://github.com/brunch/brunch/issues', title: 'Github Issues'},
       {href: 'https://github.com/paulmillr/ostio', title: 'Ost.io Example App'},


### PR DESCRIPTION
tests link goes to the document root instead of relative to index (gives wrong location when in subdirectory, e.g.)
