### PR TITLE
Fix infinite import loop in generated collection file

### DIFF
--- a/generators/collection/generator.json
+++ b/generators/collection/generator.json
@@ -2,7 +2,7 @@
   "files": [
     {
       "from": "collection.coffee.hbs",
-      "to": "app/models/{{name}}.coffee"
+      "to": "app/models/{{pluralName}}.coffee"
     }
   ],
   "dependencies": [

--- a/generators/collection_test/collection_test.coffee.hbs
+++ b/generators/collection_test/collection_test.coffee.hbs
@@ -1,0 +1,12 @@
+Collection = require 'models/base/collection'
+{{#camelize}}{{name}}{{/camelize}} = require 'models/{{name}}'
+{{#camelize}}{{pluralName}}{{/camelize}} = require 'models/{{pluralName}}'
+
+describe '{{#camelize}}{{name}}{{/camelize}}', ->
+  beforeEach ->
+    @model = new {{#camelize}}{{name}}{{/camelize}}()
+    @collection = new {{#camelize}}{{pluralName}}{{/camelize}}()
+
+  afterEach ->
+    @model.dispose()
+    @collection.dispose()

--- a/generators/collection_test/generator.json
+++ b/generators/collection_test/generator.json
@@ -2,7 +2,7 @@
   "files": [
     {
       "from": "collection_test.coffee.hbs",
-      "to": "test/models/{{name}}_test.coffee"
+      "to": "test/models/{{pluralName}}_test.coffee"
     }
   ],
   "dependencies": []


### PR DESCRIPTION
This fixes an infinite require loop where the collection would attempt to import itself at the top of its own file. This is because the collection uses `{{name}}` for the model's name as well as in the generator for the collection.

The correct incantation seems to be to use the singular name for both the model and collection generator:
- `brunch g model filter`
  - creates **models/filter.coffee** and **test/models/filter_test.coffee**
- `brunch g collection filter`
  - creates **models/filters.coffee** and **test/models/filters_test.coffee**

See that the collection filename looks almost identical to the model filename.

Personally I'm a fan of using `models/{{name}}_collection.coffee` rather than just `models/{{pluralName}}.coffee`, since I think it removes some ambiguity.
