### PR TITLE
Correct test naming scheme

### DIFF
--- a/generators/model_test/generator.json
+++ b/generators/model_test/generator.json
@@ -2,7 +2,7 @@
   "files": [
     {
       "from": "model_test.coffee.hbs",
-      "to": "test/models/{{name}}.coffee"
+      "to": "test/models/{{name}}_test.coffee"
     }
   ],
   "dependencies": []

--- a/generators/view_test/generator.json
+++ b/generators/view_test/generator.json
@@ -2,7 +2,7 @@
   "files": [
     {
       "from": "view_test.coffee.hbs",
-      "to": "test/views/{{name}}_view.coffee"
+      "to": "test/views/{{name}}_view_test.coffee"
     }
   ],
   "dependencies": []


### PR DESCRIPTION
The demo app's tests don't map to generator's naming scheme and won't get destroyed / updated / etc properly.

Also changes the controller and collection test generators to leave off the `_test` suffix
