### PR TITLE
Fix relative script load path

### DIFF
--- a/app/assets/index.html
+++ b/app/assets/index.html
@@ -9,8 +9,8 @@
   <title>Brunch example application</title>
   <meta name="viewport" content="width=device-width">
   <link rel="stylesheet" href="stylesheets/app.css">
-  <script src="javascripts/vendor.js"></script>
-  <script src="javascripts/app.js"></script>
+  <script src="/javascripts/vendor.js"></script>
+  <script src="/javascripts/app.js"></script>
   <script>require('initialize');</script>
 </head>
 <body>


### PR DESCRIPTION
Fixes a routing bug where navigating to `app.io/foo` would try to load main js scripts from `appdir/foo/script.js` (already fixed on ost.io)
