### PR TITLE
Update the Handlebars helper to use the URL helper

### DIFF
--- a/app/lib/view-helper.coffee
+++ b/app/lib/view-helper.coffee
@@ -1,4 +1,4 @@
-mediator = require 'mediator'
+Chaplin = require 'chaplin'
 
 # Application-specific view helpers
 # http://handlebarsjs.com/#helpers
@@ -21,10 +21,6 @@ Handlebars.registerHelper 'without', (context, options) ->
   options.fn = inverse
   Handlebars.helpers.with.call(this, context, options)
 
-# Get Chaplin-declared named routes. {{#url "like" "105"}}{{/url}}
-Handlebars.registerHelper 'url', (routeName, params..., options) ->
-  url = null
-  # Backbone events are synchronous, so this is possible.
-  mediator.publish '!router:reverse', routeName, params, (result) ->
-    url = if result then "/#{result}" else routeName
-  url
+# Get Chaplin-declared named routes. {{url "like" "105"}}
+Handlebars.registerHelper 'url', (routeName, params...) ->
+  Chaplin.helpers.reverse routeName, params...


### PR DESCRIPTION
This is mergeable once chaplinjs/chaplin#469 gets tagged in a release.
