### PR TITLE
Fixes the NO_BOWER_JSON error.

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,0 +1,3 @@
+{
+	"directory": "bower_components"
+}


### PR DESCRIPTION
It fixes error caused because default bower packages directory sometimes is set to `components` (for me on windows for example, i dont know why).

> 15 Aug 07:33:21 - error: { [Error: Component must have "C:\Users\Asus\brunch-with-chaplin\bower_components\chaplin\bower.json"] code: 'NO_BOWER_JSON' }

For me after merge & `bower install` error disappears.

> $> brunch watch --server
> 15 Aug 07:33:53 - info: application started on http://localhost:3333/
> 15 Aug 07:33:56 - info: compiled 27 files and 1 cached into 3 files, copied index.html in 3384ms
