### PR TITLE
Fixing the extending of Chaplin's optionNames in the base view

### DIFF
--- a/app/views/base/view.coffee
+++ b/app/views/base/view.coffee
@@ -2,7 +2,7 @@ require 'lib/view-helper' # Just load the view helpers, no return value
 
 module.exports = class View extends Chaplin.View
   # Auto-save `template` option passed to any view as `@template`.
-  optionNames: Chaplin.View.concat ['template']
+  optionNames: Chaplin.View::optionNames.concat ['template']
 
   # Precompiled templates function initializer.
   getTemplateFunction: ->


### PR DESCRIPTION
Just tried to generate a `brunch-with-chaplin` project and ran into an issue as soon as I started the application with `brunch watch --server`.

![screen shot 2013-10-25 at 14 29 52](https://f.cloud.github.com/assets/459267/1405330/ce07ab46-3d25-11e3-93c3-8e0cbfa1fcbf.png)
_[..]_
![screen shot 2013-10-25 at 14 30 02](https://f.cloud.github.com/assets/459267/1405332/d1f24770-3d25-11e3-9ef6-abe603a9287d.png)

I'm completely new to Brunch & Chaplin so I'm not entirely sure about what I'm doing, but this seems to solve the problem.
